### PR TITLE
Update CreateImage.md

### DIFF
--- a/intl.en-US/API Reference/Images/CreateImage.md
+++ b/intl.en-US/API Reference/Images/CreateImage.md
@@ -8,7 +8,7 @@ When you call this interface, consider the following:
 
 -   You can use a custom image only after its status becomes **Available** \(`Available`\).
 
--   If the specified instance is [locked](intl.en-US/API Reference/Appendix/API behavior when an instance is locked for security reasons.md#), and the `OperationLocks` of the instance indicates `LockReason:  "security"`.
+-   If the specified instance is [locked](intl.en-US/API Reference/Appendix/API behavior when an instance is locked for security reasons.md#), and the `OperationLocks` of the instance indicates `LockReason:  "security"`.You Can’t create custom image.
 
 
 **Approaches**


### PR DESCRIPTION
被 安全控制 的 ECS 实例的 OperationLocks 中标记了 "LockReason" : "security" 时，不能创建自定义镜像。