### PR TITLE
Update 实例元数据概述.md

### DIFF
--- a/cn.zh-CN/实例/管理实例/使用实例元数据/实例元数据概述.md
+++ b/cn.zh-CN/实例/管理实例/使用实例元数据/实例元数据概述.md
@@ -56,6 +56,7 @@
 |/vpc-cidr-block|实例所属VPC CIDR段。|2016-01-01|
 |/vswitch-cidr-block|实例所属虚拟交换机CIDR段。|2016-01-01|
 |/vswitch-id|实例所属虚拟交换机ID。|2016-01-01|
+|/ram/security-credentials|实例RAM角色名称。只有在实例指定了RAM角色后，您才能获取角色名称。|2016-01-01|
 |/ram/security-credentials/\[role-name\]|实例RAM角色策略所生成的STS临时凭证。只有在实例指定了RAM角色后，您才能获取STS临时凭证。其中\[role-name\]参数需要替换为实例RAM角色的名称。 **说明：** STS临时凭证更新时间早于凭证失效前半小时，在这半小时内，新旧STS临时凭证均可以使用。
 
  |2016-01-01|


### PR DESCRIPTION
文档中缺少关于 /ram/security-credentials 的描述。
文档中只提到 /ram/security-credentials/[role-name] 可以获取 STS token，
却未提及 /ram/security-credentials 可以获取 role-name。
让我一直认为在使用 RAM Role Credential 的时候必须提前指定 role-name，非常不灵活。直到今天阅读 Go SDK 源码的时候才发现了原来可以通过元数据获取 role-name。
参考上面的 /network/interfaces/macs ，我认为 /ram/security-credentials 也应该作为一个单独的API列出来。